### PR TITLE
fix: NullPointerException

### DIFF
--- a/sdk-updates/src/com/android/tools/idea/updater/AndroidSdkUpdaterPlugin.java
+++ b/sdk-updates/src/com/android/tools/idea/updater/AndroidSdkUpdaterPlugin.java
@@ -99,10 +99,13 @@ public class AndroidSdkUpdaterPlugin implements ApplicationComponent {
     @Override
     @Nullable
     public PasswordAuthentication getPasswordAuthentication() {
-      String host = getRequestingURL().toString();
-      PasswordAuthentication result = getAuthentication(host);
-      if (result != null) {
-        return result;
+      URL url = getRequestingURL();
+      if (url != null) {
+        String host = url.toString();
+        PasswordAuthentication result = getAuthentication(host);
+        if (result != null) {
+          return result;
+        }
       }
       return getAuthentication(CommonProxy.getHostNameReliably(getRequestingHost(), getRequestingSite(), getRequestingURL()));
     }


### PR DESCRIPTION
java.lang.NullPointerException
	at com.android.tools.idea.updater.AndroidSdkUpdaterPlugin$AndroidAuthenticator.getPasswordAuthentication(AndroidSdkUpdaterPlugin.java:102)
	at com.intellij.util.proxy.CommonProxy$CommonAuthenticator.getPasswordAuthentication(CommonProxy.java:286)
	at java.net.Authenticator.requestPasswordAuthentication(Authenticator.java:248)
	at java.net.SocksSocketImpl$2.run(SocksSocketImpl.java:162)
	at java.net.SocksSocketImpl$2.run(SocksSocketImpl.java:160)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.SocksSocketImpl.authenticate(SocksSocketImpl.java:159)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:472)
	at java.net.Socket.connect(Socket.java:589)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:432)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:527)
	at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264)
	at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:367)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:191)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1181)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1032)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:177)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1546)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474)
	at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480)
	... 23 more