### PR TITLE
IDEA-191821 ClassCastException on Manifest Merging

### DIFF
--- a/jps-plugin/src/org/jetbrains/jps/android/AndroidManifestMergingBuilder.java
+++ b/jps-plugin/src/org/jetbrains/jps/android/AndroidManifestMergingBuilder.java
@@ -152,7 +152,7 @@ public class AndroidManifestMergingBuilder
 
     final ManifestMerger2.Invoker manifestMergerInvoker =
       ManifestMerger2.newMerger(manifestFile, NullLogger.getLogger(), ManifestMerger2.MergeType.APPLICATION).addLibraryManifests(
-        (File[])libManifests.stream().toArray());
+        libManifests.toArray(new File[0]));
 
     MergingReport mergingReport;
     try {


### PR DESCRIPTION
IDEA-191821 Error when try to build NOT gradle android project with library android with "Enable manifest merging"

Avoids the ClassCastException