### PR TITLE
Replace WindowsComboBoxUI with BasicComboBoxUI for EnumEditor.java

### DIFF
--- a/designer/src/com/android/tools/idea/common/property/editors/EnumEditor.java
+++ b/designer/src/com/android/tools/idea/common/property/editors/EnumEditor.java
@@ -35,7 +35,7 @@ import com.intellij.ui.ColoredListCellRenderer;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.scale.JBUIScale;
 import com.intellij.util.ui.JBUI;
-import com.sun.java.swing.plaf.windows.WindowsComboBoxUI;
+import javax.swing.plaf.basic.BasicComboBoxUI;
 import org.jetbrains.android.dom.attrs.AttributeDefinition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -466,7 +466,7 @@ abstract public class EnumEditor extends BaseComponentEditor implements NlCompon
 
     @Override
     public void setUI(ComboBoxUI ui) {
-      myUseDarculaUI = !(ui instanceof WindowsComboBoxUI) && !ApplicationManager.getApplication().isUnitTestMode();
+      myUseDarculaUI = !(ui instanceof BasicComboBoxUI) && !ApplicationManager.getApplication().isUnitTestMode();
       if (myUseDarculaUI) {
         // There are multiple reasons for hardcoding the ComboBoxUI here:
         // 1) Some LAF will draw a beveled border which does not look good in the table grid.


### PR DESCRIPTION
Reference PR: 
https://github.com/JetBrains/android/pull/17  
  
Issue:  
https://stackoverflow.com/questions/53437209/how-to-handle-missing-swing-plaf-classes-in-java-11  
  
```  
java.lang.NoClassDefFoundError: com/sun/java/swing/plaf/windows/WindowsComboBoxUI
	at com.android.tools.idea.common.property.editors.EnumEditor$CustomComboBox.setUI(EnumEditor.java:470)
	at java.desktop/javax.swing.JComboBox.updateUI(JComboBox.java:277)
	at java.desktop/javax.swing.JComboBox.init(JComboBox.java:236)
	at java.desktop/javax.swing.JComboBox.<init>(JComboBox.java:230)
	at com.intellij.openapi.ui.ComboBoxWithWidePopup.<init>(ComboBoxWithWidePopup.java:15)
	at com.intellij.openapi.ui.ComboBox.<init>(ComboBox.java:44)
	at com.android.tools.idea.common.property.editors.EnumEditor$CustomComboBox.<init>(EnumEditor.java:440)
	at com.android.tools.idea.uibuilder.property.editors.NlEnumEditor.createForInspectorWithBrowseButton(NlEnumEditor.java:45)
	at com.android.tools.idea.uibuilder.property.inspector.IdInspectorProvider$IdInspectorComponent.<init>(IdInspectorProvider.java:96)
	at com.android.tools.idea.uibuilder.property.inspector.IdInspectorProvider.createCustomInspector(IdInspectorProvider.java:74)
	at com.android.tools.idea.uibuilder.property.inspector.IdInspectorProvider.createCustomInspector(IdInspectorProvider.java:39)
	at com.android.tools.idea.common.property.inspector.InspectorProviders.createInspectorComponents(InspectorProviders.java:54)
	at com.android.tools.idea.common.property.inspector.InspectorPanel.setComponent(InspectorPanel.java:260)
	at com.android.tools.idea.uibuilder.property.NlPropertiesPanel.setItems(NlPropertiesPanel.java:281)
	at com.android.tools.idea.common.property.PropertiesManager.lambda$null$0(PropertiesManager.java:247)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:776)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:746)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:878)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:827)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:466)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:704)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:465)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.ClassNotFoundException: com.sun.java.swing.plaf.windows.WindowsComboBoxUI PluginClassLoader[org.jetbrains.android, 10.3.4] com.intellij.ide.plugins.cl.PluginClassLoader@6c933fd8
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.java:75)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 33 more  
```