### PR TITLE
Fix ProguardR8UseScopeEnlarger

### DIFF
--- a/android-lang/src/com/android/tools/idea/lang/proguardR8/ProguardR8UseScopeEnlarger.kt
+++ b/android-lang/src/com/android/tools/idea/lang/proguardR8/ProguardR8UseScopeEnlarger.kt
@@ -45,7 +45,7 @@ class ProguardR8UseScopeEnlarger : UseScopeEnlarger() {
         val proguardFiles = FileTypeIndex.getFiles(ProguardR8FileType.INSTANCE, GlobalSearchScope.allScope(project))
         CachedValueProvider.Result(proguardFiles, VirtualFileManager.VFS_STRUCTURE_MODIFICATIONS)
       }
-      if (files.isEmpty()) return null else GlobalSearchScope.filesScope(project, files)
+      return if (files.isEmpty()) null else GlobalSearchScope.filesScope(project, files)
     }
     return null
   }


### PR DESCRIPTION
Before fix ProguardR8UseScopeEnlarger always returned null scope