### PR TITLE
Handle Android Tool Windows Properly

### DIFF
--- a/android-common/src/com/android/tools/idea/AndroidEnvironmentUtils.kt
+++ b/android-common/src/com/android/tools/idea/AndroidEnvironmentUtils.kt
@@ -23,11 +23,18 @@ import org.jetbrains.android.facet.AndroidFacet
 /**
  * Returns true if called in Android Studio or if the project has an Android or an Apk facet.
  */
-fun isAndroidEnvironment(project: Project): Boolean = true
+fun isAndroidEnvironment(project: Project): Boolean =
+  IdeInfo.getInstance().isAndroidStudio || project.hasAndroidOrApkFacet()
 
 /**
  * Checks if the project contains a module with an Android or an Apk facet.
  */
 fun Project.hasAndroidOrApkFacet(): Boolean =
   ProjectFacetManager.getInstance(this).hasFacets(AndroidFacet.ID) || ApkFacetChecker.getInstance(this).hasApkFacet()
+
+/**
+ * Checks if the project contains a module with an Android facet.
+ */
+fun Project.hasAndroidFacet(): Boolean =
+  ProjectFacetManager.getInstance(this).hasFacets(AndroidFacet.ID)
 

--- a/android-common/src/com/android/tools/idea/sdk/AndroidEnvironmentChecker.kt
+++ b/android-common/src/com/android/tools/idea/sdk/AndroidEnvironmentChecker.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tools.idea.sdk
+
+import com.android.tools.idea.isAndroidEnvironment
+import com.intellij.openapi.diagnostic.debug
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ext.LibrarySearchHelper
+
+/**
+ * A [LibrarySearchHelper] that returns true if in an Android environment
+ *
+ * An Android environment is either Android Studio or IntelliJ with an Android facet.
+ *
+ * Android Tool Windows should use this instead of `ToolWindowFactory.isApplicable()` to enable
+ * themselves. This is because an IntelliJ project may start up as a non Android project but then
+ * turn into one if an Android Module is added.
+ *
+ * Unlike `ToolWindowFactory.isApplicable()`, `LibrarySearchHelper.isLibraryExists()` is reevaluated
+ * when the project changes.
+ */
+class AndroidEnvironmentChecker : LibrarySearchHelper {
+  override fun isLibraryExists(project: Project): Boolean {
+    val value = isAndroidEnvironment(project)
+    thisLogger().debug { "isLibraryExists -> $value" }
+    return value
+  }
+}

--- a/android-common/src/com/android/tools/idea/sdk/AndroidFacetChecker.kt
+++ b/android-common/src/com/android/tools/idea/sdk/AndroidFacetChecker.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tools.idea.sdk
+
+import com.android.tools.idea.hasAndroidFacet
+import com.intellij.openapi.diagnostic.debug
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ext.LibrarySearchHelper
+
+/**
+ * A [LibrarySearchHelper] that checks for an Android Facet
+ */
+class AndroidFacetChecker : LibrarySearchHelper {
+  override fun isLibraryExists(project: Project): Boolean {
+    val value = project.hasAndroidFacet()
+    thisLogger().debug { "isLibraryExists -> $value" }
+    return value
+  }
+}

--- a/android-common/src/com/android/tools/idea/sdk/AndroidOrApkFacetChecker.kt
+++ b/android-common/src/com/android/tools/idea/sdk/AndroidOrApkFacetChecker.kt
@@ -15,11 +15,19 @@
  */
 package com.android.tools.idea.sdk
 
+import com.android.tools.idea.hasAndroidOrApkFacet
+import com.intellij.openapi.diagnostic.debug
+import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ext.LibrarySearchHelper
 
-class AndroidSdkLibrarySearcher: LibrarySearchHelper {
+/**
+ * A [LibrarySearchHelper] that checks for an Android or APK Facet
+ */
+class AndroidOrApkFacetChecker : LibrarySearchHelper {
   override fun isLibraryExists(project: Project): Boolean {
-    return AndroidSdkPathStore.getInstance().androidSdkPath != null
+    val value = project.hasAndroidOrApkFacet()
+    thisLogger().debug { "isLibraryExists -> $value" }
+    return value
   }
 }

--- a/android-common/test/com/android/tools/idea/sdk/AndroidEnvironmentCheckerTest.kt
+++ b/android-common/test/com/android/tools/idea/sdk/AndroidEnvironmentCheckerTest.kt
@@ -1,0 +1,59 @@
+package com.android.tools.idea.sdk
+
+import com.android.testutils.MockitoKt.mock
+import com.android.testutils.MockitoKt.whenever
+import com.android.tools.idea.ApkFacetChecker
+import com.android.tools.idea.IdeInfo
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.DisposableRule
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
+import com.intellij.testFramework.registerOrReplaceServiceInstance
+import com.intellij.testFramework.replaceService
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+
+/**
+ * Tests for [AndroidEnvironmentChecker]
+ */
+class AndroidEnvironmentCheckerTest {
+  private val projectRule = ProjectRule()
+  private val project get() = projectRule.project
+  private val disposableRule = DisposableRule()
+  private val disposable get() = disposableRule.disposable
+
+  @get:Rule
+  val rule = RuleChain(projectRule, disposableRule)
+
+  private val mockIdeInfo by lazy { Mockito.spy(IdeInfo.getInstance()) }
+  private val mockApkFacetChecker = mock<ApkFacetChecker>()
+
+  @Test
+  fun isLibraryExists() {
+    assertThat(AndroidEnvironmentChecker().isLibraryExists(project)).isTrue()
+  }
+
+  @Test
+  fun isLibraryExists_notAndroidStudio_withoutAndroidFacet() {
+    whenever(mockIdeInfo.isAndroidStudio).thenReturn(false)
+    whenever(mockApkFacetChecker.hasApkFacet()).thenReturn(false)
+
+    ApplicationManager.getApplication().replaceService(IdeInfo::class.java, mockIdeInfo, disposable)
+    project.registerOrReplaceServiceInstance(ApkFacetChecker::class.java, mockApkFacetChecker, disposable)
+
+    assertThat(AndroidEnvironmentChecker().isLibraryExists(project)).isFalse()
+  }
+
+  @Test
+  fun isLibraryExists_notAndroidStudio_withAndroidFacet() {
+    whenever(mockIdeInfo.isAndroidStudio).thenReturn(false)
+    whenever(mockApkFacetChecker.hasApkFacet()).thenReturn(true)
+
+    ApplicationManager.getApplication().replaceService(IdeInfo::class.java, mockIdeInfo, disposable)
+    project.registerOrReplaceServiceInstance(ApkFacetChecker::class.java, mockApkFacetChecker, disposable)
+
+    assertThat(AndroidEnvironmentChecker().isLibraryExists(project)).isTrue()
+  }
+}

--- a/android-common/test/com/android/tools/idea/sdk/AndroidFacetCheckerTest.kt
+++ b/android-common/test/com/android/tools/idea/sdk/AndroidFacetCheckerTest.kt
@@ -1,0 +1,47 @@
+package com.android.tools.idea.sdk
+
+import com.android.testutils.MockitoKt.whenever
+import com.google.common.truth.Truth.assertThat
+import com.intellij.facet.ProjectFacetManager
+import com.intellij.testFramework.DisposableRule
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
+import com.intellij.testFramework.registerOrReplaceServiceInstance
+import org.jetbrains.android.facet.AndroidFacet
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+
+/**
+ * Tests for [AndroidFacetChecker]
+ */
+class AndroidFacetCheckerTest {
+  private val projectRule = ProjectRule()
+  private val project get() = projectRule.project
+  private val disposableRule = DisposableRule()
+
+  private val mockProjectFacetManager by lazy { Mockito.spy(ProjectFacetManager.getInstance(project)) }
+
+  @get:Rule
+  val rule = RuleChain(projectRule, disposableRule)
+
+  @Before
+  fun setUp() {
+    project.registerOrReplaceServiceInstance(ProjectFacetManager::class.java, mockProjectFacetManager, disposableRule.disposable)
+  }
+
+  @Test
+  fun isLibraryExists() {
+    whenever(mockProjectFacetManager.hasFacets(AndroidFacet.ID)).thenReturn(true)
+
+    assertThat(AndroidFacetChecker().isLibraryExists(project)).isTrue()
+  }
+
+  @Test
+  fun isLibraryExists_withoutAndroidFacet() {
+    whenever(mockProjectFacetManager.hasFacets(AndroidFacet.ID)).thenReturn(false)
+
+    assertThat(AndroidFacetChecker().isLibraryExists(project)).isFalse()
+  }
+}

--- a/android-common/test/com/android/tools/idea/sdk/AndroidOrApkFacetCheckerTest.kt
+++ b/android-common/test/com/android/tools/idea/sdk/AndroidOrApkFacetCheckerTest.kt
@@ -1,0 +1,61 @@
+package com.android.tools.idea.sdk
+
+import com.android.testutils.MockitoKt
+import com.android.testutils.MockitoKt.whenever
+import com.android.tools.idea.ApkFacetChecker
+import com.google.common.truth.Truth.assertThat
+import com.intellij.facet.ProjectFacetManager
+import com.intellij.testFramework.DisposableRule
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
+import com.intellij.testFramework.registerOrReplaceServiceInstance
+import org.jetbrains.android.facet.AndroidFacet
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+
+/**
+ * Tests for [AndroidOrApkFacetChecker]
+ */
+class AndroidOrApkFacetCheckerTest {
+  private val projectRule = ProjectRule()
+  private val project get() = projectRule.project
+  private val disposableRule = DisposableRule()
+
+  private val mockProjectFacetManager by lazy { Mockito.spy(ProjectFacetManager.getInstance(project)) }
+  private val mockApkFacetChecker = MockitoKt.mock<ApkFacetChecker>()
+
+  @get:Rule
+  val rule = RuleChain(projectRule, disposableRule)
+
+  @Before
+  fun setUp() {
+    project.registerOrReplaceServiceInstance(ProjectFacetManager::class.java, mockProjectFacetManager, disposableRule.disposable)
+    project.registerOrReplaceServiceInstance(ApkFacetChecker::class.java, mockApkFacetChecker, disposableRule.disposable)
+  }
+
+  @Test
+  fun isLibraryExists_hasAndroidFacet() {
+    whenever(mockProjectFacetManager.hasFacets(AndroidFacet.ID)).thenReturn(true)
+    whenever(mockApkFacetChecker.hasApkFacet()).thenReturn(false)
+
+    assertThat(AndroidOrApkFacetChecker().isLibraryExists(project)).isTrue()
+  }
+
+  @Test
+  fun isLibraryExists_hasApkFacet() {
+    whenever(mockProjectFacetManager.hasFacets(AndroidFacet.ID)).thenReturn(false)
+    whenever(mockApkFacetChecker.hasApkFacet()).thenReturn(true)
+
+    assertThat(AndroidOrApkFacetChecker().isLibraryExists(project)).isTrue()
+  }
+
+  @Test
+  fun isLibraryExists_withoutFacets() {
+    whenever(mockProjectFacetManager.hasFacets(AndroidFacet.ID)).thenReturn(false)
+    whenever(mockApkFacetChecker.hasApkFacet()).thenReturn(false)
+
+    assertThat(AndroidOrApkFacetChecker().isLibraryExists(project)).isFalse()
+  }
+}

--- a/android/src/com/android/tools/idea/ui/resourcemanager/META-INF/resources-explorer.xml
+++ b/android/src/com/android/tools/idea/ui/resourcemanager/META-INF/resources-explorer.xml
@@ -42,10 +42,11 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <projectService serviceImplementation="com.android.tools.idea.ui.resourcemanager.importer.ImportConfigurationManager"/>
-    <facet.toolWindow id="Resources Explorer"
-                      facetIdList="android"
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
+    <library.toolWindow id="Resources Explorer"
                       anchor="left" icon="StudioIcons.Shell.ToolWindows.VISUAL_ASSETS" doNotActivateOnStart="true"
-                factoryClass="com.android.tools.idea.ui.resourcemanager.ResourceExplorerToolFactory"/>
+                        librarySearchClass="com.android.tools.idea.sdk.AndroidFacetChecker"
+                        factoryClass="com.android.tools.idea.ui.resourcemanager.ResourceExplorerToolFactory"/>
   </extensions>
 
   <actions>

--- a/android/testSrc/com/android/tools/idea/ui/resourcemanager/ResourceExplorerToolFactoryTest.kt
+++ b/android/testSrc/com/android/tools/idea/ui/resourcemanager/ResourceExplorerToolFactoryTest.kt
@@ -1,0 +1,28 @@
+package com.android.tools.idea.ui.resourcemanager
+
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.android.tools.idea.sdk.AndroidFacetChecker
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.fail
+
+/**
+ * Tests for [ResourceExplorerToolFactory]
+ */
+class ResourceExplorerToolFactoryTest {
+  @get:Rule
+  val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow =
+      LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Resources Explorer" }
+      ?: fail("Tool window not found")
+
+    assertThat(toolWindow.librarySearchClass)
+      .isEqualTo(AndroidFacetChecker::class.qualifiedName)
+  }
+}

--- a/app-inspection/ide/src/META-INF/app-inspection.xml
+++ b/app-inspection/ide/src/META-INF/app-inspection.xml
@@ -19,8 +19,9 @@
     <applicationService
         serviceInterface="com.android.tools.idea.appinspection.ide.InspectorArtifactService"
         serviceImplementation="com.android.tools.idea.appinspection.ide.InspectorArtifactServiceImpl"/>
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
     <library.toolWindow id="App Inspection"
-                      librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+                      librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
                       anchor="bottom"
                       icon="StudioIcons.Shell.ToolWindows.INSPECTION"
                       factoryClass="com.android.tools.idea.appinspection.ide.ui.AppInspectionToolWindowFactory"

--- a/app-inspection/ide/src/com/android/tools/idea/appinspection/ide/ui/AppInspectionToolWindowFactory.kt
+++ b/app-inspection/ide/src/com/android/tools/idea/appinspection/ide/ui/AppInspectionToolWindowFactory.kt
@@ -31,7 +31,7 @@ internal const val APP_INSPECTION_ID = "App Inspection"
 class AppInspectionToolWindowFactory : DumbAware, ToolWindowFactory {
 
   override fun isApplicable(project: Project) =
-    StudioFlags.ENABLE_APP_INSPECTION_TOOL_WINDOW.get() && isAndroidEnvironment(project)
+    StudioFlags.ENABLE_APP_INSPECTION_TOOL_WINDOW.get()
 
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
     val appInspectionToolWindow = AppInspectionToolWindow(toolWindow, project)

--- a/app-inspection/ide/testSrc/com/android/tools/idea/appinspection/ide/ui/AppInspectionToolWindowFactoryTest.kt
+++ b/app-inspection/ide/testSrc/com/android/tools/idea/appinspection/ide/ui/AppInspectionToolWindowFactoryTest.kt
@@ -1,0 +1,24 @@
+package com.android.tools.idea.appinspection.ide.ui
+
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.fail
+
+/** Tests for [AppInspectionToolWindowFactory] */
+class AppInspectionToolWindowFactoryTest {
+  @get:Rule val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow =
+      LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "App Inspection" }
+        ?: fail("Tool window not found")
+
+    assertThat(toolWindow.librarySearchClass)
+      .isEqualTo(AndroidEnvironmentChecker::class.qualifiedName)
+  }
+}

--- a/app-quality-insights/ide/src/META-INF/app-insights.xml
+++ b/app-quality-insights/ide/src/META-INF/app-insights.xml
@@ -16,8 +16,9 @@
 <idea-plugin>
   <depends>org.intellij.intelliLang</depends>
   <extensions defaultExtensionNs="com.intellij">
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
     <library.toolWindow id="App Quality Insights"
-                librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+                librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
                 anchor="bottom"
                 icon="StudioIcons.Shell.ToolWindows.APP_QUALITY_INSIGHTS"
                 factoryClass="com.android.tools.idea.insights.ui.AppInsightsToolWindowFactory"

--- a/app-quality-insights/ide/src/com/android/tools/idea/insights/ui/AppInsightsToolWindowFactory.kt
+++ b/app-quality-insights/ide/src/com/android/tools/idea/insights/ui/AppInsightsToolWindowFactory.kt
@@ -72,7 +72,7 @@ class AppInsightsToolWindowFactory : DumbAware, ToolWindowFactory {
   }
 
   override fun isApplicable(project: Project) =
-    StudioFlags.APP_INSIGHTS_ENABLED.get() && IdeInfo.getInstance().isAndroidStudio
+    StudioFlags.APP_INSIGHTS_ENABLED.get()
 
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
     createTabs(project, toolWindow)

--- a/app-quality-insights/ide/tests/com/android/tools/idea/insights/ui/AppInsightsToolWindowFactoryTest.kt
+++ b/app-quality-insights/ide/tests/com/android/tools/idea/insights/ui/AppInsightsToolWindowFactoryTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tools.idea.insights.ui
+
+import com.android.tools.idea.insights.persistence.AppInsightsSettings
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.components.service
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RunsInEdt
+import com.intellij.toolWindow.ToolWindowHeadlessManagerImpl.MockToolWindow
+import com.jetbrains.rd.generator.nova.fail
+import org.junit.Rule
+import org.junit.Test
+
+class AppInsightsToolWindowFactoryTest {
+  @get:Rule val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow =
+      LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find {
+        it.id == "App Quality Insights"
+      }
+      ?: fail("Tool window not found")
+
+    assertThat(toolWindow.librarySearchClass)
+      .isEqualTo(AndroidEnvironmentChecker::class.qualifiedName)
+  }
+}

--- a/designer/src/META-INF/designer.xml
+++ b/designer/src/META-INF/designer.xml
@@ -47,8 +47,7 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <library.toolWindow factoryClass="com.android.tools.idea.uibuilder.visual.VisualizationToolWindowFactory"
-                librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+    <toolWindow factoryClass="com.android.tools.idea.uibuilder.visual.VisualizationToolWindowFactory"
                 id="Layout Validation" anchor="right" icon="StudioIcons.Shell.ToolWindows.MULTI_PREVIEW" canCloseContents="false" />
     <projectService serviceImplementation="com.android.tools.idea.uibuilder.handlers.ViewHandlerManager" headlessImplementation="" />
     <projectService serviceImplementation="com.android.tools.idea.uibuilder.editor.LayoutNavigationManager" />

--- a/device-explorer/intellij.android.device-explorer.tests.iml
+++ b/device-explorer/intellij.android.device-explorer.tests.iml
@@ -25,5 +25,6 @@
     <orderEntry type="module" module-name="intellij.platform.core" scope="TEST" />
     <orderEntry type="module" module-name="intellij.platform.extensions" scope="TEST" />
     <orderEntry type="module" module-name="intellij.platform.util" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.platform.testFramework" scope="TEST" />
   </component>
 </module>

--- a/device-explorer/src/META-INF/intellij.android.device-explorer.xml
+++ b/device-explorer/src/META-INF/intellij.android.device-explorer.xml
@@ -32,11 +32,12 @@
     <projectService serviceInterface="com.android.tools.idea.device.explorer.files.fs.DeviceFileDownloaderService"
                     serviceImplementation="com.android.tools.idea.device.explorer.files.fs.DeviceFileDownloaderServiceImpl" />
 
-    <facet.toolWindow id="Device Explorer"
-                facetIdList="android,apk"
-                anchor="right"
-                secondary="true"
-                icon="StudioIcons.Shell.ToolWindows.DEVICE_EXPLORER"
-                factoryClass="com.android.tools.idea.device.explorer.DeviceExplorerToolWindowFactory"/>
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
+    <library.toolWindow id="Device Explorer"
+                        anchor="right"
+                        secondary="true"
+                        icon="StudioIcons.Shell.ToolWindows.DEVICE_EXPLORER"
+                        librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
+                        factoryClass="com.android.tools.idea.device.explorer.DeviceExplorerToolWindowFactory"/>
   </extensions>
 </idea-plugin>

--- a/device-explorer/src/com/android/tools/idea/device/explorer/DeviceExplorerToolWindowFactory.kt
+++ b/device-explorer/src/com/android/tools/idea/device/explorer/DeviceExplorerToolWindowFactory.kt
@@ -38,7 +38,7 @@ import java.nio.file.Path
 class DeviceExplorerToolWindowFactory : DumbAware, ToolWindowFactory {
 
   override fun isApplicable(project: Project) =
-    StudioFlags.MERGED_DEVICE_FILE_EXPLORER_AND_DEVICE_MONITOR_TOOL_WINDOW_ENABLED.get()  && isAndroidEnvironment(project)
+    StudioFlags.MERGED_DEVICE_FILE_EXPLORER_AND_DEVICE_MONITOR_TOOL_WINDOW_ENABLED.get()
 
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
     toolWindow.setIcon(StudioIcons.Shell.ToolWindows.DEVICE_EXPLORER)

--- a/device-explorer/testSrc/com/android/tools/idea/device/explorer/DeviceExplorerToolWindowFactoryTest.kt
+++ b/device-explorer/testSrc/com/android/tools/idea/device/explorer/DeviceExplorerToolWindowFactoryTest.kt
@@ -1,0 +1,24 @@
+package com.android.tools.idea.device.explorer
+
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Tests for [DeviceExplorerToolWindowFactory]
+ */
+class DeviceExplorerToolWindowFactoryTest {
+  @get:Rule
+  val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow = LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Device Explorer" }
+                     ?: throw AssertionError("Tool window not found")
+
+    assertThat(toolWindow.librarySearchClass).isEqualTo(AndroidEnvironmentChecker::class.qualifiedName)
+  }
+}

--- a/device-file-explorer-toolwindow/src/META-INF/android.device-file-explorer-toolwindow.xml
+++ b/device-file-explorer-toolwindow/src/META-INF/android.device-file-explorer-toolwindow.xml
@@ -38,10 +38,12 @@
                     serviceImplementation="com.android.tools.idea.file.explorer.toolwindow.DeviceExplorerFileManagerImpl" />
     <projectService serviceInterface="com.android.tools.idea.file.explorer.toolwindow.fs.DeviceFileDownloaderService"
                     serviceImplementation="com.android.tools.idea.file.explorer.toolwindow.fs.DeviceFileDownloaderServiceImpl" />
-    <toolWindow id="Device File Explorer"
-                anchor="right"
-                secondary="true"
-                icon="StudioIcons.Shell.ToolWindows.DEVICE_EXPLORER"
-                factoryClass="com.android.tools.idea.file.explorer.toolwindow.DeviceExplorerToolWindowFactory"/>
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
+    <library.toolWindow id="Device File Explorer"
+                        anchor="right"
+                        secondary="true"
+                        icon="StudioIcons.Shell.ToolWindows.DEVICE_EXPLORER"
+                        librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
+                        factoryClass="com.android.tools.idea.file.explorer.toolwindow.DeviceExplorerToolWindowFactory"/>
   </extensions>
 </idea-plugin>

--- a/device-file-explorer-toolwindow/src/com/android/tools/idea/file/explorer/toolwindow/DeviceExplorerToolWindowFactory.java
+++ b/device-file-explorer-toolwindow/src/com/android/tools/idea/file/explorer/toolwindow/DeviceExplorerToolWindowFactory.java
@@ -41,7 +41,6 @@ public class DeviceExplorerToolWindowFactory implements DumbAware, ToolWindowFac
   @Override
   public boolean isApplicable(@NotNull Project project) {
     return SystemProperties.getBooleanProperty(DEVICE_EXPLORER_ENABLED, true) &&
-           isAndroidEnvironment(project) &&
            !StudioFlags.MERGED_DEVICE_FILE_EXPLORER_AND_DEVICE_MONITOR_TOOL_WINDOW_ENABLED.get();
   }
 

--- a/device-file-explorer-toolwindow/testSrc/com/android/tools/idea/file/explorer/toolwindow/DeviceExplorerToolWindowFactoryTest.kt
+++ b/device-file-explorer-toolwindow/testSrc/com/android/tools/idea/file/explorer/toolwindow/DeviceExplorerToolWindowFactoryTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tools.idea.file.explorer.toolwindow
+
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Tests for [DeviceExplorerToolWindowFactory]
+ */
+class DeviceExplorerToolWindowFactoryTest {
+  @get:Rule
+  val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow = LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Device File Explorer" }
+                     ?: throw AssertionError("Tool window not found")
+
+    assertThat(toolWindow.librarySearchClass).isEqualTo(AndroidEnvironmentChecker::class.qualifiedName)
+  }
+}

--- a/device-manager-v2/src/META-INF/device-manager-v2.xml
+++ b/device-manager-v2/src/META-INF/device-manager-v2.xml
@@ -15,8 +15,9 @@
   -->
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
     <library.toolWindow id="Device Manager 2"
-                librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+                librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
                 anchor="right"
                 icon="StudioIcons.Shell.ToolWindows.DEVICE_MANAGER"
                 factoryClass="com.android.tools.idea.devicemanagerv2.DeviceManager2ToolWindowFactory"/>

--- a/device-manager-v2/src/com/android/tools/idea/devicemanagerv2/DeviceManager2ToolWindowFactory.kt
+++ b/device-manager-v2/src/com/android/tools/idea/devicemanagerv2/DeviceManager2ToolWindowFactory.kt
@@ -26,7 +26,7 @@ import com.intellij.ui.content.ContentFactory
 internal class DeviceManager2ToolWindowFactory : ToolWindowFactory, DumbAware {
 
   override fun isApplicable(project: Project): Boolean =
-    isAndroidEnvironment(project) && StudioFlags.UNIFIED_DEVICE_MANAGER_ENABLED.get()
+    StudioFlags.UNIFIED_DEVICE_MANAGER_ENABLED.get()
 
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
     val content =

--- a/device-manager-v2/testSrc/com/android/tools/idea/devicemanagerv2/DeviceManager2ToolWindowFactoryTest.kt
+++ b/device-manager-v2/testSrc/com/android/tools/idea/devicemanagerv2/DeviceManager2ToolWindowFactoryTest.kt
@@ -1,0 +1,26 @@
+package com.android.tools.idea.devicemanagerv2
+
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+/** Tests for [DeviceManager2ToolWindowFactory] */
+class DeviceManager2ToolWindowFactoryTest {
+  @get:Rule
+  val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow =
+      LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Device Manager 2" }
+      ?: throw AssertionError("Tool window not found")
+
+    Assert.assertEquals(
+      toolWindow.librarySearchClass,
+      AndroidEnvironmentChecker::class.qualifiedName
+    )
+  }
+}

--- a/device-manager/src/META-INF/device-manager.xml
+++ b/device-manager/src/META-INF/device-manager.xml
@@ -15,8 +15,9 @@
   -->
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
     <library.toolWindow id="Device Manager"
-                librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+                librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
                 anchor="right"
                 icon="StudioIcons.Shell.ToolWindows.DEVICE_MANAGER"
                 factoryClass="com.android.tools.idea.devicemanager.DeviceManagerToolWindowFactory"/>

--- a/device-manager/src/com/android/tools/idea/devicemanager/DeviceManagerToolWindowFactory.java
+++ b/device-manager/src/com/android/tools/idea/devicemanager/DeviceManagerToolWindowFactory.java
@@ -54,11 +54,6 @@ public final class DeviceManagerToolWindowFactory implements ToolWindowFactory, 
   }
 
   @Override
-  public boolean isApplicable(@NotNull Project project) {
-    return AndroidEnvironmentUtils.isAndroidEnvironment(project);
-  }
-
-  @Override
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow window) {
     Disposable parent = Disposer.newDisposable("Device Manager parent");
     JComponent pane = newJBTabbedPane(project, parent);

--- a/device-manager/testSrc/com/android/tools/idea/devicemanager/DeviceManagerToolWindowFactoryTest.kt
+++ b/device-manager/testSrc/com/android/tools/idea/devicemanager/DeviceManagerToolWindowFactoryTest.kt
@@ -18,9 +18,11 @@ package com.android.tools.idea.devicemanager
 import com.android.tools.idea.devicemanager.physicaltab.PhysicalDevicePanel
 import com.android.tools.idea.devicemanager.virtualtab.VirtualDevicePanel
 import com.android.tools.idea.devicemanager.virtualtab.VirtualDeviceWatcher
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
 import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ProjectRule
 import com.intellij.toolWindow.ToolWindowHeadlessManagerImpl
@@ -150,5 +152,13 @@ class DeviceManagerToolWindowFactoryTest {
     factory.createToolWindowContent(project, toolWindow2)
     val tabs2 = toolWindow2.contentManager.contents[0].component as JBTabbedPane
     assertEquals("Physical", tabs2.getTitleAt(tabs2.selectedIndex))
+  }
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow = LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Device Manager" }
+                     ?: throw AssertionError("Tool window not found")
+
+    assertEquals(toolWindow.librarySearchClass, AndroidEnvironmentChecker::class.qualifiedName)
   }
 }

--- a/layout-inspector/src/META-INF/layout-inspector.xml
+++ b/layout-inspector/src/META-INF/layout-inspector.xml
@@ -36,11 +36,12 @@
     <fileType name="Layout Inspector" extensions="li"
               implementationClass="com.android.tools.idea.layoutinspector.snapshots.LayoutInspectorFileType" fieldName="INSTANCE"/>
 
-    <facet.toolWindow id="Layout Inspector"
-                      facetIdList="android"
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
+    <library.toolWindow id="Layout Inspector"
                       anchor="bottom"
                       secondary="true"
                       icon="StudioIcons.Shell.ToolWindows.CAPTURES"
+                      librarySearchClass="com.android.tools.idea.sdk.AndroidFacetChecker"
                       factoryClass="com.android.tools.idea.layoutinspector.LayoutInspectorToolWindowFactory"/>
     <projectService serviceImplementation="com.android.tools.idea.layoutinspector.ui.InspectorBannerService"/>
 

--- a/layout-inspector/testSrc/com/android/tools/idea/layoutinspector/LayoutInspectorToolWindowFactoryTest.kt
+++ b/layout-inspector/testSrc/com/android/tools/idea/layoutinspector/LayoutInspectorToolWindowFactoryTest.kt
@@ -34,6 +34,8 @@ import com.android.tools.idea.layoutinspector.ui.DeviceViewContentPanel
 import com.android.tools.idea.layoutinspector.ui.DeviceViewPanel
 import com.android.tools.idea.layoutinspector.ui.InspectorRenderSettings
 import com.android.tools.idea.layoutinspector.util.ReportingCountDownLatch
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.android.tools.idea.sdk.AndroidFacetChecker
 import com.android.tools.idea.testing.AndroidProjectRule
 import com.android.tools.idea.testing.ui.flatten
 import com.android.tools.idea.transport.TransportService
@@ -48,6 +50,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowBalloonShowOptions
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
 import com.intellij.project.TestProjectManager
 import com.intellij.testFramework.ApplicationRule
 import com.intellij.testFramework.DisposableRule
@@ -69,6 +72,7 @@ import org.mockito.Mockito.anyString
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.util.concurrent.TimeUnit
+import kotlin.test.fail
 
 private val MODERN_PROCESS = MODERN_DEVICE.createProcess()
 private val LEGACY_PROCESS = LEGACY_DEVICE.createProcess()
@@ -223,6 +227,18 @@ class LayoutInspectorToolWindowFactoryTest {
     assertThat(inspector.treeSettings).isInstanceOf(InspectorTreeSettings::class.java)
     val contentPanel = component.flatten(false).firstIsInstance<DeviceViewContentPanel>()
     assertThat(inspector.renderLogic.renderSettings).isInstanceOf(InspectorRenderSettings::class.java)
+  }
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow =
+      LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find {
+        it.id == "Layout Inspector"
+      }
+      ?: fail("Tool window not found")
+
+    assertThat(toolWindow.librarySearchClass)
+      .isEqualTo(AndroidFacetChecker::class.qualifiedName)
   }
 }
 

--- a/logcat/src/META-INF/logcat.xml
+++ b/logcat/src/META-INF/logcat.xml
@@ -16,9 +16,10 @@
 
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
     <library.toolWindow
         id="Logcat"
-        librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+        librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
         anchor="bottom"
         icon="StudioIcons.Shell.ToolWindows.LOGCAT"
         canCloseContents="true"

--- a/logcat/src/com/android/tools/idea/logcat/LogcatToolWindowFactory.kt
+++ b/logcat/src/com/android/tools/idea/logcat/LogcatToolWindowFactory.kt
@@ -102,8 +102,6 @@ internal class LogcatToolWindowFactory : SplittingTabsToolWindowFactory(), DumbA
 
   override fun shouldCreateNewTabWhenEmpty() = !insideShowLogcatListener
 
-  override fun isApplicable(project: Project) = isAndroidEnvironment(project)
-
   override fun generateTabName(tabNames: Set<String>) =
     UniqueNameGenerator.generateUniqueName("Logcat", "", "", " (", ")") { !tabNames.contains(it) }
 

--- a/logcat/testSrc/com/android/tools/idea/logcat/LogcatToolWindowFactoryTest.kt
+++ b/logcat/testSrc/com/android/tools/idea/logcat/LogcatToolWindowFactoryTest.kt
@@ -18,9 +18,7 @@ package com.android.tools.idea.logcat
 import com.android.processmonitor.monitor.ProcessNameMonitor
 import com.android.processmonitor.monitor.testing.FakeProcessNameMonitor
 import com.android.testutils.MockitoKt.mock
-import com.android.testutils.MockitoKt.whenever
 import com.android.tools.adtui.TreeWalker
-import com.android.tools.idea.IdeInfo
 import com.android.tools.idea.logcat.LogcatPanelConfig.FormattingConfig
 import com.android.tools.idea.logcat.devices.Device
 import com.android.tools.idea.logcat.devices.DeviceComboBoxDeviceTrackerFactory
@@ -32,12 +30,13 @@ import com.android.tools.idea.logcat.service.LogcatService
 import com.android.tools.idea.logcat.util.waitForCondition
 import com.android.tools.idea.run.ShowLogcatListener
 import com.android.tools.idea.run.ShowLogcatListener.DeviceInfo.PhysicalDeviceInfo
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
 import com.android.tools.idea.testing.ProjectServiceRule
 import com.google.common.truth.Truth.assertThat
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionGroup
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
 import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.EdtRule
 import com.intellij.testFramework.ProjectRule
@@ -49,8 +48,8 @@ import com.intellij.toolWindow.ToolWindowHeadlessManagerImpl.MockToolWindow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import kotlin.test.fail
 
 
 @RunsInEdt
@@ -82,13 +81,12 @@ class LogcatToolWindowFactoryTest {
   }
 
   @Test
-  fun isApplicable_nonAndroidEnvironment() {
-    val mockIdeInfo = spy(IdeInfo.getInstance())
-    whenever(mockIdeInfo.isAndroidStudio).thenReturn(false)
-    ApplicationManager.getApplication().replaceService(IdeInfo::class.java, mockIdeInfo, disposableRule.disposable)
+  fun isLibraryToolWindow() {
+    val toolWindow = LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Logcat" } ?: fail("Tool window not found")
 
-    assertThat(logcatToolWindowFactory().isApplicable(project)).isFalse()
+    assertThat(toolWindow.librarySearchClass).isEqualTo(AndroidEnvironmentChecker::class.qualifiedName)
   }
+
 
   @Test
   fun generateTabName_noPreExistingNames() {

--- a/profilers-android/src/META-INF/profilers.xml
+++ b/profilers-android/src/META-INF/profilers.xml
@@ -15,8 +15,9 @@
   -->
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
     <library.toolWindow id="Android Profiler"
-                      librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+                      librarySearchClass="com.android.tools.idea.sdk.AndroidOrApkFacetChecker"
                       anchor="bottom"
                       icon="StudioIcons.Shell.ToolWindows.ANDROID_PROFILER"
                       factoryClass="com.android.tools.idea.profilers.AndroidProfilerToolWindowFactory"

--- a/profilers-android/testSrc/com/android/tools/idea/profilers/AndroidProfilerToolWindowFactoryTest.kt
+++ b/profilers-android/testSrc/com/android/tools/idea/profilers/AndroidProfilerToolWindowFactoryTest.kt
@@ -1,0 +1,28 @@
+package com.android.tools.idea.profilers
+
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.android.tools.idea.sdk.AndroidOrApkFacetChecker
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.fail
+
+/**
+ * Tests for [AndroidProfilerToolWindowFactory]
+ */
+class AndroidProfilerToolWindowFactoryTest {
+  @get:Rule
+  val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow =
+      LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Android Profiler" }
+      ?: fail("Tool window not found")
+
+    assertThat(toolWindow.librarySearchClass)
+      .isEqualTo(AndroidOrApkFacetChecker::class.qualifiedName)
+  }
+}

--- a/streaming/src/META-INF/streaming.xml
+++ b/streaming/src/META-INF/streaming.xml
@@ -28,8 +28,9 @@
 
     <customizableActionGroupProvider implementation="com.android.tools.idea.streaming.emulator.actions.EmulatorCustomizableActionGroupProvider"/>
 
+    <!--suppress PluginXmlValidity - Plugin XML files are merged into the same plugin.xml -->
     <library.toolWindow id="Running Devices"
-                librarySearchClass="com.android.tools.idea.sdk.AndroidSdkLibrarySearcher"
+                librarySearchClass="com.android.tools.idea.sdk.AndroidEnvironmentChecker"
                 anchor="right"
                 secondary="true"
                 canCloseContents="true"

--- a/streaming/src/com/android/tools/idea/streaming/StreamingToolWindowFactory.kt
+++ b/streaming/src/com/android/tools/idea/streaming/StreamingToolWindowFactory.kt
@@ -53,7 +53,7 @@ class StreamingToolWindowFactory : ToolWindowFactory, DumbAware {
   }
 
   override fun isApplicable(project: Project): Boolean {
-    return isAndroidEnvironment(project) && (canLaunchEmulator() || DeviceMirroringSettings.getInstance().deviceMirroringEnabled)
+    return (canLaunchEmulator() || DeviceMirroringSettings.getInstance().deviceMirroringEnabled)
   }
 
   private fun canLaunchEmulator(): Boolean =

--- a/streaming/testSrc/com/android/tools/idea/streaming/StreamingToolWindowFactoryTest.kt
+++ b/streaming/testSrc/com/android/tools/idea/streaming/StreamingToolWindowFactoryTest.kt
@@ -1,0 +1,25 @@
+package com.android.tools.idea.streaming
+
+import com.android.tools.idea.sdk.AndroidEnvironmentChecker
+import com.intellij.openapi.wm.ext.LibraryDependentToolWindow
+import com.intellij.testFramework.ProjectRule
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.fail
+
+/**
+ * Tests for [StreamingToolWindowFactory]
+ */
+class StreamingToolWindowFactoryTest {
+  @get:Rule
+  val projectRule = ProjectRule()
+
+  @Test
+  fun isLibraryToolWindow() {
+    val toolWindow = LibraryDependentToolWindow.EXTENSION_POINT_NAME.extensions.find { it.id == "Running Devices" }
+                     ?: fail("Tool window not found")
+
+    Assert.assertEquals(toolWindow.librarySearchClass, AndroidEnvironmentChecker::class.qualifiedName)
+  }
+}


### PR DESCRIPTION
All Android Tool Windows that are defined in the Android Plugin should be defined as `<library.toolWindow>` and protected with an appropriate `LibrarySearchHelper` based on their scope.